### PR TITLE
adds RoundingMode argument to round

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # User visible changes in TwoDimensional package
 
+## Version 0.3.2
+
+- `round` has a `r::RoundingMode` optional argument.
+
 ## Version 0.3.1
 
 - Julia 0.7 is supported.

--- a/docs/src/BoundingBoxes.md
+++ b/docs/src/BoundingBoxes.md
@@ -208,9 +208,9 @@ Given the bounding-box `B`, [`interior(B)`](@ref interior) and
 [`exterior(B)`](@ref exterior) respectively yield the largest interior and
 smallest exterior bounding-boxes with integer bounds.
 
-[`round(B)`](@ref round) or [`round(T,B)`](@ref round) yield a bounding-box
-whose limits are those of the bounding-box `B` rounded to the nearest integer
-values.
+[`round(B)`](@ref round) or [`round(T,B)`](@ref round)  or [`round(T,B,r)`](@ref round) yield a
+bounding-box whose limits are those of the bounding-box `B` rounded to the nearest integer
+values, with rounding mode `r` (default is `RoundNearest`).
 
 [`center(B)`](@ref center) yields the `Point` whose coordinates are the
 geometrical center of the bounding-box `B`.

--- a/docs/src/Points.md
+++ b/docs/src/Points.md
@@ -181,12 +181,13 @@ distance(Point(x1,y1),Point(x2,y2)  # yields hypot(x1-x2,y1-y2)
 The nearest point to an instance `obj` of [`Point`](@ref) is given by:
 
 ```julia
-round([T,] obj)
+round([T,] obj, [r::RoundingMode])
 ```
 
 which rounds the coordinates of `obj` to the nearest integer.  Optional
 argument `T` is to specify the type of the result or the type of the
-coordinates of the result.
+coordinates of the result. Optional argument `r` is to set the rounding
+mode, the default is `RoundNearest`.
 
 Similarly, `floor([T,],P)` and `ceil([T,],P)` yield the point with integer
 coordinates immediately (inclusively) before and after [`Point`](@ref) `P`.

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -40,7 +40,7 @@ exterior
 ## Methods
 
 ```@docs
-round(::Point)
+round(::Union{Point,BoundingBox})
 floor(::Point)
 ceil(::Point)
 ```

--- a/src/basics.jl
+++ b/src/basics.jl
@@ -181,11 +181,11 @@ Base.promote_type(::Type{WeightedPoint{T}}, ::Type{WeightedPoint{T}}) where {T} 
     WeightedPoint{T}
 
 """
-    round([T,] obj::Union{Point,BoundingBox})
+    round([T,] obj::Union{Point,BoundingBox}, [r::RoundingMode])
 
-yields the object that is the nearest to `obj` by rounding its coordinates to
-the nearest integer.  Argument `T` can be the type of the result (a point or a
-bounding-box) or the type of the coordinates of the result.
+yields the object that is the nearest to `obj` by rounding its coordinates. Argument `T` can be the
+type of the result (a point or a bounding-box) or the type of the coordinates of the result.
+Rounding mode is set by optional argument `r` with `RoundNearest` as default.
 
 For points, see also: [`floor(::Point)`](@ref), [`ceil(::Point)`](@ref).
 
@@ -193,41 +193,49 @@ For bounding-boxes, see also: [`interior`](@ref), [`exterior`](@ref).
 
 """
 Base.round(obj::Point{T}) where {T} = round(T, obj)
+Base.round(obj::Point{T}, r::RoundingMode) where {T} = round(T, obj, r)
 Base.round(::Type{Point{T}}, obj::Point) where {T} = round(T, obj)
+Base.round(::Type{Point{T}}, obj::Point, r::RoundingMode) where {T} = round(T, obj, r)
 Base.round(::Type{T}, obj::Point{T}) where {T<:Integer} = obj
-Base.round(::Type{T}, obj::Point{T}) where {T<:Real} =
-    Point(round(obj.x, RoundNearest),
-          round(obj.y, RoundNearest))
+Base.round(::Type{T}, obj::Point{T}, r::RoundingMode=RoundNearest) where {T<:Real} =
+    Point(round(obj.x, r),
+          round(obj.y, r))
 Base.round(::Type{T}, obj::Point{<:Integer}) where {T<:Integer} =
     Point{T}(obj)
-Base.round(::Type{T}, obj::Point{<:Real}) where {T<:Integer} =
-    Point(round(T, obj.x, RoundNearest),
-          round(T, obj.y, RoundNearest))
+Base.round(::Type{T}, obj::Point{<:Real}, r::RoundingMode=RoundNearest) where {T<:Integer} =
+    Point(round(T, obj.x, r),
+          round(T, obj.y, r))
 Base.round(::Type{T}, obj::Point{<:Integer}) where {T<:Real} =
     Point{T}(obj)
 Base.round(::Type{T}, obj::Point{U}) where {T<:Real,U<:Real} =
     Point{T}(round(U, obj))
+Base.round(::Type{T}, obj::Point{U}, r::RoundingMode) where {T<:Real,U<:Real} =
+    Point{T}(round(U, obj, r))
 
 # Extend round for bounding-boxes.
 Base.round(obj::BoundingBox{T}) where {T} = round(T, obj)
+Base.round(obj::BoundingBox{T}, r::RoundingMode) where {T} = round(T, obj, r)
 Base.round(::Type{BoundingBox{T}}, obj::BoundingBox) where {T} = round(T, obj)
+Base.round(::Type{BoundingBox{T}}, obj::BoundingBox, r::RoundingMode) where {T} = round(T, obj, r)
 Base.round(::Type{T}, obj::BoundingBox{T}) where {T<:Integer} = obj
-Base.round(::Type{T}, obj::BoundingBox{T}) where {T<:Real} =
-    BoundingBox(round(obj.xmin, RoundNearest),
-                round(obj.xmax, RoundNearest),
-                round(obj.ymin, RoundNearest),
-                round(obj.ymax, RoundNearest))
+Base.round(::Type{T}, obj::BoundingBox{T}, r::RoundingMode=RoundNearest) where {T<:Real} =
+    BoundingBox(round(obj.xmin, r),
+                round(obj.xmax, r),
+                round(obj.ymin, r),
+                round(obj.ymax, r))
 Base.round(::Type{T}, obj::BoundingBox{<:Integer}) where {T<:Integer} =
     BoundingBox{T}(obj)
-Base.round(::Type{T}, obj::BoundingBox{<:Real}) where {T<:Integer} =
-    BoundingBox(round(T, obj.xmin, RoundNearest),
-                round(T, obj.xmax, RoundNearest),
-                round(T, obj.ymin, RoundNearest),
-                round(T, obj.ymax, RoundNearest))
+Base.round(::Type{T}, obj::BoundingBox{<:Real}, r::RoundingMode=RoundNearest) where {T<:Integer} =
+    BoundingBox(round(T, obj.xmin, r),
+                round(T, obj.xmax, r),
+                round(T, obj.ymin, r),
+                round(T, obj.ymax, r))
 Base.round(::Type{T}, obj::BoundingBox{<:Integer}) where {T<:Real} =
     BoundingBox{T}(obj)
 Base.round(::Type{T}, obj::BoundingBox{U}) where {T<:Real,U<:Real} =
     BoundingBox{T}(round(U, obj))
+Base.round(::Type{T}, obj::BoundingBox{U}, r::RoundingMode) where {T<:Real,U<:Real} =
+    BoundingBox{T}(round(U, obj, r))
 
 """
     floor([T,] P::Point)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -114,6 +114,10 @@ end
         @test round(Point{Int}, Point(1.6,-0.7)) === Point(2,-1)
         @test round(Int, Point(1.2,-0.7)) === Point(1,-1)
         @test round(Point{Int}, Point(1.6,-0.7)) === Point(2,-1)
+        @test round(Point(1.5, 2.5)) === Point(2.0, 2.0)
+        @test round(Point(1.5, 2.5), RoundNearestTiesUp) === Point(2.0, 3.0)
+        @test round(Float32, Point{Float64}(1.5e0, 2.5e0), RoundNearestTiesUp) ===
+            Point{Float32}(2f0, 3f0)
         # floor
         @test floor(Point(-1,3)) === Point(-1,3)
         @test floor(Int, Point(-1,3)) === Point(-1,3)
@@ -289,6 +293,11 @@ end
             BoundingBox{Float32}(1,2,-4,8)
         @test round(Float32, BoundingBox(1.1,2.7,-4.6,8.3)) ===
             BoundingBox{Float32}(1,3,-5,8)
+        @test round(BoundingBox(1.5, 2.5, 3.5, 9.9)) === BoundingBox(2.0, 2.0, 4.0, 10.0)
+        @test round(BoundingBox(1.5, 2.5, 3.5, 9.9), RoundNearestTiesUp) ===
+            BoundingBox(2.0, 3.0, 4.0, 10.0)
+        @test round(Float32, BoundingBox{Float64}(1.5e0, 2.5e0, 3.5e0, 9.9e0), RoundNearestTiesUp) ===
+            BoundingBox{Float32}(2f0, 3f0, 4f0, 10f0)
         # exterior
         @test exterior(B) === B
         @test exterior(Int, B) === B


### PR DESCRIPTION
- argument is optional, default value is RoundNearest
- for methods with existing rounding as this one:
  ```julia
  Base.round(::Type{T}, obj::Point{<:Real}) where {T<:Integer} =
    Point(round(T, obj.x, RoundNearest),
               round(T, obj.y, RoundNearest))
  ```
  I add a rounding parameter in the method, like this:
  ```julia
  Base.round(::Type{T}, obj::Point{<:Real}, r::RoundingMode=RoundNearest) where {T<:Integer} =
    Point(round(T, obj.x, r),
               round(T, obj.y, r)
  ```
  But I do *not* do it for methods with Integer type as this one:
  ```julia
  Base.round(::Type{T}, obj::Point{<:Integer}) where {T<:Integer} = Point{T}(obj)
  ```
- For "wrapper" methods as this one:
  ```julia
  Base.round(obj::BoundingBox{T}) where {T} = round(T, obj)
  ```
  I added an additional method as this one:
  ```julia
  Base.round(obj::BoundingBox{T}, r::RoundingMode) where {T} = round(T, obj, r)
  ```
  I do *not* use optional arguments, because if you do, they will *always* be filled. And we  don't want to always have the parameter, see previous bullet
- added 6 tests
- updated news and docs
- did *not* bumped version in project.toml